### PR TITLE
Update PHP version and illuminate/support for Lumen v8.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^7.2",
-        "illuminate/support": "^7.0"
+        "illuminate/support": "^7.0 | ^8.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5"


### PR DESCRIPTION
Changes proposed in this pull request:

 * Requires PHP 7.3
 * Accepts illuminate/support 7.x or 8.x
 
Ideally, you would create a new tag with only `^8.0`.

NOTE: currently fails on PHP 7.2 (which reaches end of life in Nov. 2020). May be the right time to remove it from CI and add 7.4